### PR TITLE
add issue on failing github actions

### DIFF
--- a/.github/workflows/automaticReleaseAndPush.yml
+++ b/.github/workflows/automaticReleaseAndPush.yml
@@ -97,38 +97,8 @@ jobs:
           commitish: ${{ steps.auto-commit-action.outputs.commit_hash }} # Ignored if empty, i.e. no commit because of no change
 
   notify_failure:
-    runs-on: ubuntu-latest
-    needs: check_for_new_helm_version_and_push_image
-    permissions:
-      issues: write
-      contents: read
+    uses: ./.github/workflows/notify_failure.yml
+    needs: [ check_for_new_helm_version_and_push_image ]
     if: failure()
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    steps:
-      - name: Manage issue
-        id: manage_issue
-        run: |
-          ISSUE_TITLE="[Workflow Log] Central error logging"
-          ISSUE_DATA=$(gh issue list -R "$GITHUB_REPOSITORY" --search "is:open in:title \"${ISSUE_TITLE}\"" --json number --limit 1)
-          ISSUE_NUMBER=$(echo "$ISSUE_DATA" | jq -r '.[0].number')
-          
-          if [ -z "$ISSUE_NUMBER" ] || [ "$ISSUE_NUMBER" = "null" ]; then
-            NEW_ISSUE_NUMBER=$(gh issue create -R "$GITHUB_REPOSITORY" --title "$ISSUE_TITLE" \
-                                               --body "This issue serves as a central log for all workflow errors." \
-                                                | sed -n 's/.*#\([0-9]\+\).*/\1/p')
-            echo "issue_number=$NEW_ISSUE_NUMBER" >> "$GITHUB_OUTPUT"
-          else              
-            echo "issue_number=$ISSUE_NUMBER" >> "$GITHUB_OUTPUT"
-          fi                   
-
-      - name: Create comment
-        id: create_comment
-        run: |
-          if [ -z "${{ steps.manage_issue.outputs.issue_number }}" ] || [ "${{ steps.manage_issue.outputs.issue_number }}" = "null" ]; then
-            echo "Issue number not found!"
-            exit 1
-          else
-            gh issue comment ${{ steps.manage_issue.outputs.issue_number }} -R "$GITHUB_REPOSITORY" --body "***Workflow failure*** ([View workflow run for details](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}))"
-          fi
+    with:
+      needs_job: check_for_new_helm_version_and_push_image

--- a/.github/workflows/automaticReleaseAndPush.yml
+++ b/.github/workflows/automaticReleaseAndPush.yml
@@ -98,7 +98,7 @@ jobs:
 
   notify_failure:
     runs-on: ubuntu-latest
-    needs: check_for_new_helm_version_and_push_image:
+    needs: check_for_new_helm_version_and_push_image
     permissions:
       issues: write
       contents: read

--- a/.github/workflows/automaticReleaseAndPush.yml
+++ b/.github/workflows/automaticReleaseAndPush.yml
@@ -95,3 +95,40 @@ jobs:
           draft: false
           prerelease: false
           commitish: ${{ steps.auto-commit-action.outputs.commit_hash }} # Ignored if empty, i.e. no commit because of no change
+
+  notify_failure:
+    runs-on: ubuntu-latest
+    needs: check_for_new_helm_version_and_push_image:
+    permissions:
+      issues: write
+      contents: read
+    if: failure()
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Manage issue
+        id: manage_issue
+        run: |
+          ISSUE_TITLE="[Workflow Log] Central error logging"
+          ISSUE_DATA=$(gh issue list -R "$GITHUB_REPOSITORY" --search "is:open in:title \"${ISSUE_TITLE}\"" --json number --limit 1)
+          ISSUE_NUMBER=$(echo "$ISSUE_DATA" | jq -r '.[0].number')
+          
+          if [ -z "$ISSUE_NUMBER" ] || [ "$ISSUE_NUMBER" = "null" ]; then
+            NEW_ISSUE_NUMBER=$(gh issue create -R "$GITHUB_REPOSITORY" --title "$ISSUE_TITLE" \
+                                               --body "This issue serves as a central log for all workflow errors." \
+                                                | sed -n 's/.*#\([0-9]\+\).*/\1/p')
+            echo "issue_number=$NEW_ISSUE_NUMBER" >> "$GITHUB_OUTPUT"
+          else              
+            echo "issue_number=$ISSUE_NUMBER" >> "$GITHUB_OUTPUT"
+          fi                   
+
+      - name: Create comment
+        id: create_comment
+        run: |
+          if [ ! -z "${{ steps.manage_issue.outputs.issue_number }}" ] || [ "${{ steps.manage_issue.outputs.issue_number }}" != "null" ]; then
+            echo "Issue number not found!"
+            exit 1
+          else
+            gh issue comment ${{ steps.manage_issue.outputs.issue_number }} -R "$GITHUB_REPOSITORY" --body "***Workflow failure*** ([View workflow run for details](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}))"
+          fi

--- a/.github/workflows/automaticReleaseAndPush.yml
+++ b/.github/workflows/automaticReleaseAndPush.yml
@@ -97,6 +97,10 @@ jobs:
           commitish: ${{ steps.auto-commit-action.outputs.commit_hash }} # Ignored if empty, i.e. no commit because of no change
 
   notify_failure:
+    permissions:
+      issues: write
+      contents: read
+
     uses: ./.github/workflows/notify_failure.yml
     needs: [ check_for_new_helm_version_and_push_image ]
     if: failure()

--- a/.github/workflows/automaticReleaseAndPush.yml
+++ b/.github/workflows/automaticReleaseAndPush.yml
@@ -126,7 +126,7 @@ jobs:
       - name: Create comment
         id: create_comment
         run: |
-          if [ ! -z "${{ steps.manage_issue.outputs.issue_number }}" ] || [ "${{ steps.manage_issue.outputs.issue_number }}" != "null" ]; then
+          if [ -z "${{ steps.manage_issue.outputs.issue_number }}" ] || [ "${{ steps.manage_issue.outputs.issue_number }}" = "null" ]; then
             echo "Issue number not found!"
             exit 1
           else

--- a/.github/workflows/notify_failure.yml
+++ b/.github/workflows/notify_failure.yml
@@ -1,0 +1,47 @@
+name: Notify Failure
+
+on:
+  workflow_call:
+    inputs:
+      needs_job:
+        required: true
+        type: string
+    secrets:
+      GITHUB_TOKEN:
+        required: true
+
+jobs:
+  notify_failure:
+    runs-on: ubuntu-latest
+    needs:
+      - ${{ inputs.needs_job }}
+    permissions:
+      issues: write
+      contents: read
+    if: failure()
+
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Manage issue
+        id: manage_issue
+        run: |
+          ISSUE_TITLE="[Workflow Log] Central error logging"
+          ISSUE_DATA=$(gh issue list -R "$GITHUB_REPOSITORY" --search "is:open in:title \"${ISSUE_TITLE}\"" --json number --limit 1)
+          ISSUE_NUMBER=$(echo "$ISSUE_DATA" | jq -r '.[0].number')
+          
+          if [ -z "$ISSUE_NUMBER" ] || [ "$ISSUE_NUMBER" = "null" ]; then
+            NEW_ISSUE_NUMBER=$(gh issue create -R "$GITHUB_REPOSITORY" --title "$ISSUE_TITLE" \
+                                               --body "This issue serves as a central log for all workflow errors." \
+                                                | sed -n 's/.*#\([0-9]\+\).*/\1/p')
+            echo "issue_number=$NEW_ISSUE_NUMBER" >> "$GITHUB_OUTPUT"
+          else              
+            echo "issue_number=$ISSUE_NUMBER" >> "$GITHUB_OUTPUT"
+          fi                   
+
+      - name: Create comment
+        run: |
+          gh issue comment ${{ steps.manage_issue.outputs.issue_number }} \
+             -R "$GITHUB_REPOSITORY" \
+             --body "***Workflow failure*** ([View workflow run for details](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}))"


### PR DESCRIPTION
See RM #55707

- Other PRs: 
https://github.com/cloudogu/mailhog-image/pull/1
https://github.com/cloudogu/helm-docker/pull/6


### How to test the github change action before merging:

Create an example repository e.g. xyz on github and create a github actions file like this. Either via the github editor or while creating a new file and put it under the .github/workflows/ directory:

/gihub_repo/.github/workflows/main_task.yml - First job - Failing simulation

```
name: "Main task"

permissions:
  issues: write
  contents: read

on:
  push:
    branches: ['*']
  pull_request:
    types: [opened, synchronize, reopened]

jobs:
  main_task:
    runs-on: ubuntu-latest
    steps:
      - name: Checkout Code
        uses: actions/checkout@v4
      - name: Will fail on purpose
        run: |
          echo "Führe wichtige Tests aus..."
          # Diese Zeile simuliert einen Fehler. Bei Erfolg entfernen Sie 'exit 1'.
          exit 1

  notify_failure:
    uses: ./.github/workflows/notify_failure.yml
    needs: [main_task]
    if: failure()
    with:
      needs_job: main_task
```

/gihub_repo/.github/workflows/notify_failure.yml - Second job - Issue handling itself
```
name: Notify Failure

on:
  workflow_call:
    inputs:
      needs_job:
        required: true
        type: string

permissions:
  issues: write
  contents: read

jobs:
  notify_failure:
    runs-on: ubuntu-latest

    env:
      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

    steps:
      - name: Manage issue
        id: manage_issue
        run: |
          ISSUE_TITLE="[Workflow Log] Central error logging"
          ISSUE_DATA=$(gh issue list -R "$GITHUB_REPOSITORY" --search "is:open in:title \"${ISSUE_TITLE}\"" --json number --limit 1)
          ISSUE_NUMBER=$(echo "$ISSUE_DATA" | jq -r '.[0].number')
          
          if [ -z "$ISSUE_NUMBER" ] || [ "$ISSUE_NUMBER" = "null" ]; then
            NEW_ISSUE_NUMBER=$(gh issue create -R "$GITHUB_REPOSITORY" --title "$ISSUE_TITLE" \
                                               --body "This issue serves as a central log for all workflow errors." \
                                                | sed -n 's/.*#\([0-9]\+\).*/\1/p')
            echo "issue_number=$NEW_ISSUE_NUMBER" >> "$GITHUB_OUTPUT"
          else              
            echo "issue_number=$ISSUE_NUMBER" >> "$GITHUB_OUTPUT"
          fi                   

      - name: Create comment
        run: |
          gh issue comment ${{ steps.manage_issue.outputs.issue_number }} \
             -R "$GITHUB_REPOSITORY" \
             --body "***Workflow failure*** ([View workflow run for details](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}))"

```



On every commit or push, the GitHub Actions workflow runs:

**The first job simulates** a failure so that the comment and issue creation job is triggered. It is not part of the actual pull request itself; it only exists to demonstrate how to test the workflow.

**The second** job performs two important steps:

2.1 The first step checks whether a general issue for workflow runs already exists. If it does not, a new issue is created. The ID of this newly created issue is then passed to the next step.

2.2 In the second step, a comment is posted—using the GitHub CLI, the API, and a token—on the previously found or newly created issue, based on the failed workflow run.

This allows anyone interested to subscribe to the issue and stay informed about workflow failures.